### PR TITLE
Change the format of Landing page to conform with Gov.uk standards, format tests and add urls to application.properties

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
@@ -11,11 +11,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/payments/{paymentId}/payment-summary")
 public class PaymentSummaryController  {
 
-    private static final String TEMPLATE = "payments/paymentSummary";
+    static final String PAYMENT_SUMMARY_VIEW = "payments/paymentSummary";
 
     @GetMapping
     public String getPaymentSummary(@PathVariable String paymentId,
                                      Model model) {
-        return TEMPLATE;
+        return PAYMENT_SUMMARY_VIEW;
     }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
+chs.url=${CHS_URL}
+developer.url=${DEVELOPER_URL}
 cdn.url=//${CDN_HOST}

--- a/src/main/resources/templates/payments/paymentSummary.html
+++ b/src/main/resources/templates/payments/paymentSummary.html
@@ -13,19 +13,21 @@
         <form th:action="@{''}" th:object="${choosePaymentType}" method="post"
               class="form" id="choosePaymentType">
             <div class="grid-row">
-                <table>
-                    <tr>
-                        <th>Payment Description</th>
-                        <th>Amount to Pay</th>
-                    </tr>
-                    <tr>
-                        <td>Late Filing Penalty</td>
-                        <td>100</td>
-                    </tr>
-                </table>
+                <div class="column-one-half">
+                    <b>Payment Description</b>
+                </div>
+                <div class="column-one-half">
+                    <b>Amount to Pay</b>
+                </div>
             </div>
-
-            <p></p>
+            <div class="grid-row">
+                <div class="column-one-half">
+                    <p>Late Filing Penalty</p>
+                </div>
+                <div class="column-one-half">
+                    <p>100</p>
+                </div>
+            </div>
             <div class="form-group">
                 <input class="button" type="submit" role="button" value="Continue"/>
             </div>

--- a/src/main/resources/templates/payments/paymentSummary.html
+++ b/src/main/resources/templates/payments/paymentSummary.html
@@ -22,10 +22,10 @@
             </div>
             <div class="grid-row">
                 <div class="column-one-half">
-                    <p>Late Filing Penalty</p>
+                    <p></p>
                 </div>
                 <div class="column-one-half">
-                    <p>100</p>
+                    <p></p>
                 </div>
             </div>
             <div class="form-group">

--- a/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
@@ -15,17 +15,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PaymentSummaryControllerTests {
+
+    private static final String PAYMENT_ID = "paymentId";
+    private static final String PAYMENT_SUMMARY_PATH = "/payments/" + PAYMENT_ID + "/payment-summary";
 
     private MockMvc mockMvc;
 
     @InjectMocks
     private PaymentSummaryController controller;
-
-    private static final String PAYMENT_ID = "paymentId";
-    private static final String PAYMENT_SUMMARY_PATH = "/payments/" + PAYMENT_ID + "/payment-summary";
-    private static final String PAYMENT_SUMMARY_VIEW = "payments/paymentSummary";
 
     @BeforeEach
     private void setup() {
@@ -38,6 +36,6 @@ public class PaymentSummaryControllerTests {
 
         this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name(PAYMENT_SUMMARY_VIEW));
+                .andExpect(view().name(PaymentSummaryController.PAYMENT_SUMMARY_VIEW));
     }
 }


### PR DESCRIPTION
Initial styling was using the proof of concept as a template for the landing page. Changed to use Gov.uk standards when creating tables.

Addressing PR comments in https://github.com/companieshouse/payments.web.ch.gov.uk/pull/12 to develop:
Change the visibility of variables to follow dry principles
remove per class lifecycle method in test
change application properties to include more urls used in thymeleaf layouts