### PR TITLE
Adds error case for starting a payments web journey with a paid payment session

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.payments.controller;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,11 +10,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.payments.exception.ServiceException;
-import uk.gov.companieshouse.web.payments.model.Payment;
 import uk.gov.companieshouse.web.payments.model.PaymentSummary;
 import uk.gov.companieshouse.web.payments.service.externalpayment.ExternalPaymentService;
 import uk.gov.companieshouse.web.payments.service.payment.PaymentService;
 import uk.gov.companieshouse.web.payments.util.PaymentMethod;
+import uk.gov.companieshouse.web.payments.util.PaymentStatus;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,11 +45,12 @@ public class PaymentSummaryController extends BaseController {
         try {
             paymentSummary = paymentService.getPayment(paymentId);
         } catch (ServiceException e) {
-         LOGGER.errorRequest(request, e.getMessage(), e);
+            LOGGER.errorRequest(request, e.getMessage(), e);
             return ERROR_VIEW;
         }
 
-        if (paymentSummary.getStatus().equals(PaymentSummary.PAYMENT_STATUS_PAID)) {
+        if (StringUtils.equals(paymentSummary.getStatus(), (PaymentStatus.PAYMENT_STATUS_PAID.paymentStatus()))) {
+            LOGGER.errorRequest(request, "payment session status is paid, cannot pay again");
             return  ERROR_VIEW;
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.payments.exception.ServiceException;
+import uk.gov.companieshouse.web.payments.model.Payment;
+import uk.gov.companieshouse.web.payments.model.PaymentSummary;
 import uk.gov.companieshouse.web.payments.service.externalpayment.ExternalPaymentService;
 import uk.gov.companieshouse.web.payments.service.payment.PaymentService;
 import uk.gov.companieshouse.web.payments.util.PaymentMethod;
@@ -36,12 +38,21 @@ public class PaymentSummaryController extends BaseController {
     public String getPaymentSummary(@PathVariable String paymentId,
                                      Model model,
                                      HttpServletRequest request) {
+
+        PaymentSummary paymentSummary;
+
         try {
-            model.addAttribute("paymentSummary", paymentService.getPayment(paymentId));
+            paymentSummary = paymentService.getPayment(paymentId);
         } catch (ServiceException e) {
          LOGGER.errorRequest(request, e.getMessage(), e);
             return ERROR_VIEW;
         }
+
+        if (paymentSummary.getStatus().equals(PaymentSummary.PAYMENT_STATUS_PAID)) {
+            return  ERROR_VIEW;
+        }
+
+        model.addAttribute("paymentSummary", paymentSummary);
 
         return getTemplateName();
     }

--- a/src/main/java/uk/gov/companieshouse/web/payments/model/PaymentSummary.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/model/PaymentSummary.java
@@ -3,9 +3,6 @@ package uk.gov.companieshouse.web.payments.model;
 import java.util.List;
 
 public class PaymentSummary {
-    public static final String PAYMENT_STATUS_PAID = "paid";
-    public static final String PAYMENT_STATUS_PENDING = "pending";
-
     private String total;
     private List<Payment> payments;
     private String email;

--- a/src/main/java/uk/gov/companieshouse/web/payments/model/PaymentSummary.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/model/PaymentSummary.java
@@ -3,6 +3,8 @@ package uk.gov.companieshouse.web.payments.model;
 import java.util.List;
 
 public class PaymentSummary {
+    public static final String PAYMENT_STATUS_PAID = "paid";
+    public static final String PAYMENT_STATUS_PENDING = "pending";
 
     private String total;
     private List<Payment> payments;

--- a/src/main/java/uk/gov/companieshouse/web/payments/util/PaymentStatus.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/util/PaymentStatus.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.web.payments.util;
+
+public enum PaymentStatus {
+    PAYMENT_STATUS_PAID("paid"),
+    PAYMENT_STATUS_PENDING("pending");
+
+    private String paymentStatus;
+
+    private PaymentStatus(String paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
+
+    public String paymentStatus() {
+        return paymentStatus;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.payments.exception.ServiceException;
+import uk.gov.companieshouse.web.payments.model.Payment;
 import uk.gov.companieshouse.web.payments.model.PaymentSummary;
 import uk.gov.companieshouse.web.payments.service.payment.PaymentService;
 
@@ -43,7 +44,9 @@ public class PaymentSummaryControllerTests {
     @Test
     @DisplayName("Payment Summary view success path")
     void getRequestSuccess() throws Exception {
-        when(paymentService.getPayment(PAYMENT_ID)).thenReturn(new PaymentSummary());
+        PaymentSummary paymentSummary = new PaymentSummary();
+        paymentSummary.setStatus(PaymentSummary.PAYMENT_STATUS_PENDING);
+        when(paymentService.getPayment(PAYMENT_ID)).thenReturn(paymentSummary);
         this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(controller.getTemplateName()))
@@ -56,6 +59,17 @@ public class PaymentSummaryControllerTests {
 
         doThrow(ServiceException.class).when(paymentService).getPayment(PAYMENT_ID);
 
+        this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
+    }
+
+    @Test
+    @DisplayName("Get payment view failure path due to payment status being paid")
+    void getRequestErrorWhenPaymentStatusPaid() throws Exception {
+        PaymentSummary paymentSummary = new PaymentSummary();
+        paymentSummary.setStatus(PaymentSummary.PAYMENT_STATUS_PAID);
+        when(paymentService.getPayment(PAYMENT_ID)).thenReturn(paymentSummary);
         this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(ERROR_VIEW));

--- a/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/payments/controller/PaymentSummaryControllerTests.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.web.payments.exception.ServiceException;
 import uk.gov.companieshouse.web.payments.model.Payment;
 import uk.gov.companieshouse.web.payments.model.PaymentSummary;
 import uk.gov.companieshouse.web.payments.service.payment.PaymentService;
+import uk.gov.companieshouse.web.payments.util.PaymentStatus;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -45,7 +46,7 @@ public class PaymentSummaryControllerTests {
     @DisplayName("Payment Summary view success path")
     void getRequestSuccess() throws Exception {
         PaymentSummary paymentSummary = new PaymentSummary();
-        paymentSummary.setStatus(PaymentSummary.PAYMENT_STATUS_PENDING);
+        paymentSummary.setStatus(PaymentStatus.PAYMENT_STATUS_PENDING.paymentStatus());
         when(paymentService.getPayment(PAYMENT_ID)).thenReturn(paymentSummary);
         this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
                 .andExpect(status().isOk())
@@ -54,7 +55,7 @@ public class PaymentSummaryControllerTests {
     }
 
     @Test
-    @DisplayName("Get payment view failure path due to error on payment summary retrieval")
+    @DisplayName("Failure due to error on GET request for payment summary")
     void getRequestFailureInGetPayment() throws Exception {
 
         doThrow(ServiceException.class).when(paymentService).getPayment(PAYMENT_ID);
@@ -65,10 +66,10 @@ public class PaymentSummaryControllerTests {
     }
 
     @Test
-    @DisplayName("Get payment view failure path due to payment status being paid")
+    @DisplayName("Get payment processing failure due to payment status being paid")
     void getRequestErrorWhenPaymentStatusPaid() throws Exception {
         PaymentSummary paymentSummary = new PaymentSummary();
-        paymentSummary.setStatus(PaymentSummary.PAYMENT_STATUS_PAID);
+        paymentSummary.setStatus(PaymentStatus.PAYMENT_STATUS_PAID.paymentStatus());
         when(paymentService.getPayment(PAYMENT_ID)).thenReturn(paymentSummary);
         this.mockMvc.perform(get(PAYMENT_SUMMARY_PATH))
                 .andExpect(status().isOk())


### PR DESCRIPTION
Currently, there is a bug that allows a user to start and finish a payments web journey for a paid payment session. This is done by completing a payment journey and then navigating to payments/id/pay using the id of the paid payment session. This allows the user to complete another journey, through govpay, therefore paying twice for the same transaction.

The fix, in this PR, is to check the status when retrieving the payment session and displaying an error page if the status is 'paid'.

I have implemented a fix and added a unit test to cover this failure point.

### Type of change

* [x ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__