### PR TITLE
Add PR Analysis to payments web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,7 @@ dist: clean build package
 .PHONY: sonar
 sonar:
 	mvn sonar:sonar
+
+.PHONY: sonar-pr-analysis
+sonar-pr-analysis:
+	mvn sonar:sonar	-P sonar-pr-analysis

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-spring-boot-parent</artifactId>
-        <version>1.0.0-rc1</version>
+        <version>1.2.0</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,6 @@
         <joda-money.version>1.0.1</joda-money.version>
         <hamcrest-library-version>2.1</hamcrest-library-version>
         <spring-test.version>5.1.3.RELEASE</spring-test.version>
-
-        <!-- Sonar -->
-        <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
-        <sonar.host.url>${CODE_ANALYSIS_HOST_URL}</sonar.host.url>
-        <sonar.login>${CODE_ANALYSIS_LOGIN}</sonar.login>
-        <sonar.password>${CODE_ANALYSIS_PASSWORD}</sonar.password>
 
         <!-- Jacoco -->
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>


### PR DESCRIPTION
The changes will allow sonar to run analysis everytime a PR is raised against the master branch.
There is a task configured in the pipeline within Concourse that will run the analysis against each new PR raised.