### PR TITLE
Add jib plugin for building container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ Key                | Description
 Page           | Address
 ---------------|-----------------------------
 Payment Summary| `/payments/<payment_id>/pay`
+
+### Building a Docker container image
+
+This project uses jib-maven-plugin to build Docker container images. To build a container image, run the following
+command on the command line:
+
+```bash
+mvn compile jib:dockerBuild -Dimage=169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payments.web.ch.gov.uk:latest
+```

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,18 @@
+local_resource(
+  name = 'dev:payments-web-ch-gov-uk-build',
+  cmd = 'mvn compile',
+  deps = ['src']
+)
+
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payments.web.ch.gov.uk',
+  command = 'mvn compile jib:dockerBuild -Dimage=$EXPECTED_REF',
+  live_update = [
+    sync(
+      local_path = './target/classes',
+      remote_path = '/app/classes'
+    ),
+    restart_container()
+  ],
+  deps = ['./target/classes']
+)

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,16 @@
                     <maxmem>512m</maxmem>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <container>
+                        <expandClasspathDependencies>true</expandClasspathDependencies>
+                    </container>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
* Add jib plugin to project POM to allow Docker container images to be
  built for the project.
* Add Tiltfile.dev to enable development workflow in
  docker-chs-development.