### PR TITLE
Change GovPay payment method to credit-card

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/payments/util/PaymentMethodData.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/util/PaymentMethodData.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.web.payments.util;
 
 public enum PaymentMethodData {
-    GOVPAY("GovPay"),
+    GOVPAY("credit-card"),
     PAYPAL("PayPal");
 
     private String paymentMethod;

--- a/src/test/java/uk/gov/companieshouse/web/payments/service/payment/impl/PaymentServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/payments/service/payment/impl/PaymentServiceImplTests.java
@@ -40,7 +40,7 @@ public class PaymentServiceImplTests {
 
     private static final String PATCH_PAYMENT_VALID_URI = "/private/payments/" + PAYMENT_ID;
 
-    private static final String PAYMENT_METHOD_GOV_PAY = "GovPay";
+    private static final String PAYMENT_METHOD_GOV_PAY = "credit-card";
 
     @Mock
     private ApiClientService apiClientService;


### PR DESCRIPTION
There's a discrepancy between the services that use the payments-service declaring `available_payment_methods` as `credit-card` whereas payments.web and payments.api were expecting `GovPay`. This change fixes that