### PR TITLE
Fix the duplicated id for the payment methods

### DIFF
--- a/src/main/resources/templates/payments/paymentMethodChoice.html
+++ b/src/main/resources/templates/payments/paymentMethodChoice.html
@@ -32,13 +32,13 @@
                         <div class="govuk-radios" th:each="paymentMethod : ${availablePaymentMethods}" style="margin-bottom:1em;">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input"
-                                       id="availablePaymentMethod"
+                                       th:id="${paymentMethod}"
                                        name="available-payment-method"
                                        type="radio"
                                        th:value="${paymentMethod}"
                                        th:field="*{selectedPaymentMethod}"
                                        th:errorclass="govuk-error-message"/>
-                                <label class="govuk-label govuk-radios__label" for="availablePaymentMethod" th:text="${paymentMethod}">keyvalue</label>
+                                <label class="govuk-label govuk-radios__label" th:for="${paymentMethod}" th:text="${paymentMethod}">keyvalue</label>
                             </div>
                         </div>
 


### PR DESCRIPTION
Change the id for the radio button and label on each payment method to the literal string of the payment method to prevent duplicated IDs. 

Resolves: NCPP-245