### PR TITLE
Disable query params when redirecting to GovPay

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/payments/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/payments/interceptor/UserDetailsInterceptor.java
@@ -15,34 +15,44 @@ import uk.gov.companieshouse.web.payments.session.SessionService;
 @Component
 public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
 
-    private static final String USER_EMAIL = "userEmail";
+  private static final String USER_EMAIL = "userEmail";
 
-    private static final String SIGN_IN_KEY = "signin_info";
-    private static final String USER_PROFILE_KEY = "user_profile";
-    private static final String EMAIL_KEY = "email";
+  private static final String SIGN_IN_KEY = "signin_info";
+  private static final String USER_PROFILE_KEY = "user_profile";
+  private static final String EMAIL_KEY = "email";
+  private static final String SUMMARY_PARAM = "summary";
 
-    @Autowired
-    private SessionService sessionService;
+  @Autowired
+  private SessionService sessionService;
 
-    @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
-        Boolean urlContainsAPIKey = false;
+  @Override
+  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+      @Nullable ModelAndView modelAndView) throws Exception {
+    Boolean urlContainsAPIKey = false;
 
-        if (request.getRequestURI() != null) {
-            urlContainsAPIKey = request.getRequestURI().contains("api-key");
-        }
-
-        if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
-                (request.getMethod().equalsIgnoreCase("POST") &&
-                        !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX)))
-                && !urlContainsAPIKey) {
-            Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
-            Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
-            if (signInInfo != null) {
-                Map<String, Object> userProfile = (Map<String, Object>) signInInfo
-                        .get(USER_PROFILE_KEY);
-                modelAndView.addObject(USER_EMAIL, userProfile.get(EMAIL_KEY));
-            }
-        }
+    if (request.getRequestURI() != null) {
+      urlContainsAPIKey = request.getRequestURI().contains("api-key");
     }
+
+    if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
+        (request.getMethod().equalsIgnoreCase("POST") &&
+            !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX)))
+        && !urlContainsAPIKey) {
+      Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
+      Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
+        // These details should only be added when the summary screen is NOT skipped
+        // i.e. there is no summary parameter or the summary parameter is set to true.
+        // This is due to Spring adding these attributes as query parameters when
+        // redirecting in the postExternalPayment method of the
+        // PaymentSummaryController.
+        // This prevents exposing the users email address in the govpay logs.
+        if (signInInfo != null
+                && (request.getParameter(SUMMARY_PARAM) == null
+                || Boolean.valueOf(request.getParameter(SUMMARY_PARAM)) != false)) {
+            Map<String, Object> userProfile = (Map<String, Object>) signInInfo
+                .get(USER_PROFILE_KEY);
+            modelAndView.addObject(USER_EMAIL, userProfile.get(EMAIL_KEY));
+      }
+    }
+  }
 }


### PR DESCRIPTION
The issue, as described by [GOV.UK](http://gov.uk/), is that they are receiving requests including a query parameter with users email addresses e.g. E.g. /secure/1234-1234-1234-1234-1234?userEmail=user@email.com. 

This is due to spring appending model parameters when redirecting, not a manual concatenation. This PR fixes this issue by skipping the code that adds the parameters to the model if the user skips the summary screen.