### PR TITLE
payments-web adding read_only flag and set to false

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -29,7 +29,8 @@ module "secrets" {
 
 module "ecs-service" {
   source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.292"
-
+  read_only_root_filesystem = false
+  
   # Environmental configuration
   environment             = var.environment
   aws_region              = var.aws_region


### PR DESCRIPTION
logs on aws: `nAPPLICATION FAILED TO START\n***************************\n\nDescription:\n\nFailed to bind properties under 'logging.level'`

adding read_only_root_filesystem = false to try and fix this issue. 