### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,7 @@
 artifact_name       := payments.web.ch.gov.uk
 version := "unversioned"
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
 dependency_check_suppressions_repo_branch:=main
-
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
@@ -63,6 +56,7 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar	-P sonar-pr-analysis
+
 .PHONY: dependency-check
 dependency-check:
 	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
@@ -86,7 +80,7 @@ dependency-check:
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
 	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
@@ -94,3 +88,4 @@ dependency-check:
 
 .PHONY: security-check
 security-check: dependency-check
+

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
         <version>2.1.11</version>
+        <relativePath/>
     </parent>
 
     <properties>


### PR DESCRIPTION
760b3db Re-point Makefile at dep-check-suppressions/main
The 'dependency-check' target uses a variable
  dependency_check_suppressions_repo_branch
 which previously pointed to a different branch:
  feature/suppressions-for-company-accounts-api
 ... but that branch has been merged into main and so this variable
 should now point to main.
Tidied Makefile for dependency-check consistency.
Removed extraneous comments.
Made line spacing, ordering, format for dependency-check sections
 identical across Makefiles.
Added json to dependency check report formats.

db9a348 Use relativePath
relativePath prevents Maven from searching locally for the parent pom,
 forcing it to go to the standard Maven repositories.

Fixes: [CC-1713](https://companieshouse.atlassian.net/browse/CC-1713)

[CC-1713]: https://companieshouse.atlassian.net/browse/CC-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ